### PR TITLE
Fixed bugs with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Optionally, you can specify more arguments and completely customise the resultan
     "entry": "index.js",
     "out": "My Cool App.exe",
     "skipBundle": false,
-    "version": "package:version",
+    "version": "{package:version}",
     "icon": "icon.ico",
     "executionLevel": "asInvoker",
     "properties": {
-        "FileDescription": "My Cool App",
+        "FileDescription": "{package:description}",
         "ProductName": "My Cool App",
-        "LegalCopyright": "Copyright package:author.name",
-        "OriginalFilename": "package:name"
+        "LegalCopyright": "Copyright {package:author.name}",
+        "OriginalFilename": "{package:name}"
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angablue/exe",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Build a portable binary for Windows systems using Vercel's pkg",
   "main": "dist/index.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { resolve } from 'path';
 import { readFile } from 'fs/promises';
 import exe from '.';

--- a/test/exe.json
+++ b/test/exe.json
@@ -2,13 +2,13 @@
     "entry": "./test/index.js",
     "out": "./test/My Cool App.exe",
     "skipBundle": false,
-    "version": "package:version",
+    "version": "{package:version}",
     "icon": "./test/icon.ico",
     "executionLevel": "asInvoker",
     "properties": {
-        "FileDescription": "My Cool App",
+        "FileDescription": "{package:description}",
         "ProductName": "My Cool App",
-        "LegalCopyright": "Copyright package:author.name",
-        "OriginalFilename": "package:name"
+        "LegalCopyright": "Copyright {package:author.name}",
+        "OriginalFilename": "{package:name}"
     }
 }


### PR DESCRIPTION
- cli.js requires hashbang line, without this line the js file simply opens and does not execute
- the utils parse function had an issue where it was not copying non-string properties
- wrapped tokens in curly brace - "package:name" => "{package:name}" so that you can add values after such as "{package:name}.exe"